### PR TITLE
Migrated API from .NET 8.0 to .NET 6.0 for Railway compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# Use .NET 6.0 SDK for build
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+WORKDIR /app
+
+# Copy csproj files and restore dependencies
+COPY *.sln ./
+COPY PediMix.API/*.csproj ./PediMix.API/
+COPY PediMix.Application/*.csproj ./PediMix.Application/
+COPY PediMix.Domain/*.csproj ./PediMix.Domain/
+COPY PediMix.Infrastructure/*.csproj ./PediMix.Infrastructure/
+
+RUN dotnet restore
+
+# Copy source code and build
+COPY . ./
+RUN dotnet publish PediMix.API/PediMix.API.csproj -c Release -o out
+
+# Use .NET 6.0 runtime for production
+FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS runtime
+WORKDIR /app
+
+# Copy the built application
+COPY --from=build /app/out ./
+
+# Expose port
+EXPOSE 8080
+
+# Set environment variables
+ENV ASPNETCORE_URLS=http://+:8080
+ENV ASPNETCORE_ENVIRONMENT=Production
+
+# Run the application
+ENTRYPOINT ["dotnet", "PediMix.API.dll"]

--- a/PediMix.API/PediMix.API.csproj
+++ b/PediMix.API/PediMix.API.csproj
@@ -1,18 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.8">
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.21">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PediMix.API/Program.cs
+++ b/PediMix.API/Program.cs
@@ -29,19 +29,10 @@ builder.Services.AddScoped<ISongRequestRepository, SongRequestRepository>();
 builder.Services.AddScoped<IGenreRepository, GenreRepository>();
 
 // MediatR
-builder.Services.AddMediatR(cfg => {
-    cfg.RegisterServicesFromAssembly(typeof(CreateUserCommandHandler).Assembly);
-    cfg.RegisterServicesFromAssembly(typeof(GetUserByIdQueryHandler).Assembly);
-});
+builder.Services.AddMediatR(typeof(CreateUserCommandHandler).Assembly);
 
 // AutoMapper
-builder.Services.AddAutoMapper(cfg =>
-{
-    cfg.AddProfile<UserMappingProfile>();
-    cfg.AddProfile<ProfileMappingProfile>();
-    cfg.AddProfile<SongMappingProfile>();
-    cfg.AddProfile<EventMappingProfile>();
-});
+builder.Services.AddAutoMapper(typeof(UserMappingProfile).Assembly);
 
 // CORS
 builder.Services.AddCors(options =>

--- a/PediMix.Application/PediMix.Application.csproj
+++ b/PediMix.Application/PediMix.Application.csproj
@@ -5,12 +5,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="15.0.1" />
-    <PackageReference Include="MediatR" Version="13.0.0" />
+    <PackageReference Include="AutoMapper" Version="12.0.1" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
+    <PackageReference Include="MediatR" Version="11.1.0" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/PediMix.Domain/PediMix.Domain.csproj
+++ b/PediMix.Domain/PediMix.Domain.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/PediMix.Infrastructure/Migrations/20250828223035_InitialCreate.Designer.cs
+++ b/PediMix.Infrastructure/Migrations/20250828223035_InitialCreate.Designer.cs
@@ -2,7 +2,6 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using PediMix.Infrastructure.Data;
@@ -12,18 +11,15 @@ using PediMix.Infrastructure.Data;
 namespace PediMix.Infrastructure.Migrations
 {
     [DbContext(typeof(PediMixDbContext))]
-    [Migration("20250828215717_InitialCreate")]
+    [Migration("20250828223035_InitialCreate")]
     partial class InitialCreate
     {
-        /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "9.0.8")
+                .HasAnnotation("ProductVersion", "6.0.21")
                 .HasAnnotation("Relational:MaxIdentifierLength", 64);
-
-            MySqlModelBuilderExtensions.AutoIncrementColumns(modelBuilder);
 
             modelBuilder.Entity("PediMix.Domain.Entities.Address", b =>
                 {

--- a/PediMix.Infrastructure/Migrations/20250828223035_InitialCreate.cs
+++ b/PediMix.Infrastructure/Migrations/20250828223035_InitialCreate.cs
@@ -5,10 +5,8 @@ using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace PediMix.Infrastructure.Migrations
 {
-    /// <inheritdoc />
     public partial class InitialCreate : Migration
     {
-        /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.AlterDatabase()
@@ -805,7 +803,6 @@ namespace PediMix.Infrastructure.Migrations
                 unique: true);
         }
 
-        /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropTable(

--- a/PediMix.Infrastructure/Migrations/PediMixDbContextModelSnapshot.cs
+++ b/PediMix.Infrastructure/Migrations/PediMixDbContextModelSnapshot.cs
@@ -2,7 +2,6 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using PediMix.Infrastructure.Data;
 
@@ -17,10 +16,8 @@ namespace PediMix.Infrastructure.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "9.0.8")
+                .HasAnnotation("ProductVersion", "6.0.21")
                 .HasAnnotation("Relational:MaxIdentifierLength", 64);
-
-            MySqlModelBuilderExtensions.AutoIncrementColumns(modelBuilder);
 
             modelBuilder.Entity("PediMix.Domain.Entities.Address", b =>
                 {

--- a/PediMix.Infrastructure/PediMix.Infrastructure.csproj
+++ b/PediMix.Infrastructure/PediMix.Infrastructure.csproj
@@ -6,16 +6,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.8">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.21" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.21">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="6.0.2" />
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # 🎵 PediMix API
 
-**API .NET Core 8 com Arquitetura CQRS para Sistema de Gerenciamento de Eventos Musicais**
+**API .NET 6.0 com Arquitetura CQRS para Sistema de Gerenciamento de Eventos Musicais**
 
-[![.NET](https://img.shields.io/badge/.NET-8.0-blue.svg)](https://dotnet.microsoft.com/)
+[![.NET](https://img.shields.io/badge/.NET-6.0-blue.svg)](https://dotnet.microsoft.com/)
 [![MySQL](https://img.shields.io/badge/MySQL-8.0-orange.svg)](https://www.mysql.com/)
 [![Railway](https://img.shields.io/badge/Railway-Database-purple.svg)](https://railway.app/)
 [![Swagger](https://img.shields.io/badge/Swagger-OpenAPI-green.svg)](https://swagger.io/)


### PR DESCRIPTION
- Updated all project files to target .NET 6.0
- Downgraded package versions to be compatible with .NET 6.0
- Recreated migrations for EF Core 6.0
- Added Dockerfile for .NET 6.0
- Updated README.md to reflect .NET 6.0
- Fixed MediatR and AutoMapper configurations
- API successfully builds and runs on .NET 6.0